### PR TITLE
Optimize data loading for  carousel

### DIFF
--- a/blocks/article-carousel/article-carousel.js
+++ b/blocks/article-carousel/article-carousel.js
@@ -14,12 +14,11 @@ export default async function decorate(block) {
 
 async function fetchArticlesAndCreateCards(filters) {
   return ffetch('/articles.json')
-    .chunks(20)
+    .sheet('section-carousel')
     // make sure all filters match
     .filter((article) => Object.keys(filters).every(
       (key) => article[key]?.toLowerCase() === filters[key].toLowerCase(),
     ))
-    .limit(9)
     .map(async (article) => {
       const wrapper = document.createElement('div');
       const card = createCardBlock(article, wrapper);


### PR DESCRIPTION
currenty the carousel has to make around 4 requests to articles.json to get the relevant data. 
With this change, a new sheet contains all the relevant data and needs to be fetched only once. 
Most of the work was in creating the excel formulas  in the `helix-section-carousel` sheet in <https://adobe.sharepoint.com/:x:/r/sites/HelixProjects/Shared%20Documents/sites/24life/articles.xlsx?d=w3821c23a83f4433d943e847b8e662668&csf=1&web=1&e=CKIgGz>

using https://main--24life--hlxsites.hlx.page/articles.json?sheet=section-carousel

Fix #101

Test URLs:
- After: https://101-carousel-data--24life--hlxsites.hlx.page/focus/2022/leilani-fights-her-way-back-to-fitness
