### PR TITLE
#31 Fixing mp4 autoplay on chrome firefox edge

### DIFF
--- a/blocks/article-hero-video/article-hero-video.css
+++ b/blocks/article-hero-video/article-hero-video.css
@@ -63,7 +63,8 @@ div.article-hero-video-wrapper {
     letter-spacing: 1px;
 }
 
-iframe.article-hero-video-iframe{
+video.article-hero-video-element,
+iframe.article-hero-video-element{
     display: none;
 }
 
@@ -117,7 +118,8 @@ div.article-hero-video-image-container{
         display: none;
     }
 
-    iframe.article-hero-video-iframe {
+    video.article-hero-video-element,
+    iframe.article-hero-video-element {
         display: unset;
         position: absolute;
         top: 0;

--- a/blocks/article-hero-video/article-hero-video.js
+++ b/blocks/article-hero-video/article-hero-video.js
@@ -11,21 +11,26 @@ export default function decorate(block) {
   let hasVideo = false;
   // create video container
   const videoContainer = document.createElement('div');
-  videoContainer.classList.add('article-hero-video-iframe-container');
+  videoContainer.classList.add('article-hero-video-element-container');
   // create overlay container
   const overlayContainer = document.createElement('div');
   overlayContainer.classList.add('article-hero-video-overlay-container');
 
+  function buildVideo() {
+    if (isYoutubeVideo(data?.video)) {
+      videoContainer.append(buildIframe(data?.video));
+    } else {
+      // mp4 video
+      videoContainer.append(buildVideoTag(data?.video));
+    }
+    // add overlay div to avoid clicks on video
+    overlayContainer.append(addVideoOverlay());
+  }
+
   if (data?.video) {
     hasVideo = true;
     if (over900px.matches) {
-      if (isYoutubeVideo(data?.video)) {
-        videoContainer.append(buildIframe(data?.video));
-      } else {
-        videoContainer.append(buildVideoTag(data?.video));
-      }
-      // add overlay div to avoid clicks on video
-      overlayContainer.append(addVideoOverlay());
+      buildVideo();
     }
   }
   block.append(videoContainer);
@@ -38,8 +43,7 @@ export default function decorate(block) {
       if (videoContainer.querySelector('iframe')) {
         return;
       }
-      videoContainer.append(buildIframe(data?.video));
-      overlayContainer.append(addVideoOverlay());
+      buildVideo();
     } else {
       videoContainer.innerHTML = '';
       overlayContainer.innerHTML = '';
@@ -96,7 +100,7 @@ function buildVideoTag(url) {
   const video = document.createElement('video');
   video.style.width = '100%';
   video.style.height = '100%';
-  video.classList.add('article-hero-video-iframe');
+  video.classList.add('article-hero-video-element');
   video.setAttribute('preload', 'auto');
   video.setAttribute('playsinline', '');
   video.setAttribute('autoplay', '');
@@ -123,7 +127,7 @@ function buildVideoTag(url) {
 function buildIframe(url) {
   const youtubeVideoId = getYoutubeVideoId(url);
   const iframe = document.createElement('iframe');
-  iframe.classList.add('article-hero-video-iframe');
+  iframe.classList.add('article-hero-video-element');
   iframe.width = '100%';
   iframe.height = '100%';
   iframe.src = `https://www.youtube-nocookie.com/embed/${youtubeVideoId}?autoplay=1&controls=0&mute=1&loop=1&playlist=${youtubeVideoId}&rel=0&playsinline=1&modestbranding=1&cc_load_policy=1&disablekb=1&enablejsapi=1&loop=1&color=white&iv_load_policy=3`;

--- a/blocks/article-hero-video/article-hero-video.js
+++ b/blocks/article-hero-video/article-hero-video.js
@@ -106,6 +106,7 @@ function buildVideoTag(url) {
   video.muted = true;
   video.autoplay = true;
   video.loop = true;
+  video.setAttribute('muted', 'true');
 
   // Create source element for MP4
   const sourceMp4 = document.createElement('source');

--- a/blocks/article-hero-video/article-hero-video.js
+++ b/blocks/article-hero-video/article-hero-video.js
@@ -102,7 +102,6 @@ function buildVideoTag(url) {
   video.style.height = '100%';
   video.classList.add('article-hero-video-element');
   video.setAttribute('preload', 'auto');
-  video.setAttribute('playsinline', '');
   video.setAttribute('autoplay', '');
   video.setAttribute('muted', '');
   video.setAttribute('loop', '');

--- a/blocks/article-hero-video/article-hero-video.js
+++ b/blocks/article-hero-video/article-hero-video.js
@@ -19,7 +19,11 @@ export default function decorate(block) {
   if (data?.video) {
     hasVideo = true;
     if (over900px.matches) {
-      videoContainer.append(buildIframe(data?.video));
+      if (isYoutubeVideo(data?.video)) {
+        videoContainer.append(buildIframe(data?.video));
+      } else {
+        videoContainer.append(buildVideoTag(data?.video));
+      }
       // add overlay div to avoid clicks on video
       overlayContainer.append(addVideoOverlay());
     }
@@ -65,6 +69,7 @@ export default function decorate(block) {
 
   const section = document.createElement('h4');
   section.classList.add('article-hero-video-section');
+  // get section from metadata
   section.innerText = getMetadata('section');
 
   const title = document.createElement('h1');
@@ -79,6 +84,33 @@ export default function decorate(block) {
   titleContainer.append(title);
   titleContainer.append(author);
   block.append(titleContainer);
+}
+
+/**
+ * Build a video tag for an MP4 video
+ * @param url {string} URL of the video
+ * @returns {HTMLVideoElement} video element
+ */
+function buildVideoTag(url) {
+  // Create video element
+  const video = document.createElement('video');
+  video.style.width = '100%';
+  video.style.height = '100%';
+  video.classList.add('article-hero-video-iframe');
+  video.setAttribute('preload', 'auto');
+  video.setAttribute('playsinline', '');
+  video.setAttribute('autoplay', '');
+  video.setAttribute('muted', '');
+  video.setAttribute('loop', '');
+
+  // Create source element for MP4
+  const sourceMp4 = document.createElement('source');
+  sourceMp4.setAttribute('src', url);
+  sourceMp4.setAttribute('type', 'video/mp4');
+
+  // Append source to video
+  video.appendChild(sourceMp4);
+  return video;
 }
 
 /**
@@ -110,4 +142,16 @@ function getYoutubeVideoId(url) {
     youtubeVideoId = new URL(url).pathname.split('/').pop();
   }
   return youtubeVideoId;
+}
+
+/**
+ * Check if a URL is a YouTube video
+ * @param url {string}
+ * @returns {boolean} true if the URL is a YouTube video
+ */
+function isYoutubeVideo(url) {
+  return url.includes('youtube.com/watch?v=')
+    || url.includes('youtube.com/embed/')
+    || url.includes('youtu.be/')
+    || url.includes('youtube-nocookie.com/embed/');
 }

--- a/blocks/article-hero-video/article-hero-video.js
+++ b/blocks/article-hero-video/article-hero-video.js
@@ -101,10 +101,11 @@ function buildVideoTag(url) {
   video.style.width = '100%';
   video.style.height = '100%';
   video.classList.add('article-hero-video-element');
-  video.setAttribute('preload', 'auto');
-  video.setAttribute('autoplay', '');
-  video.setAttribute('muted', '');
-  video.setAttribute('loop', '');
+
+  // Set boolean attributes
+  video.muted = true;
+  video.autoplay = true;
+  video.loop = true;
 
   // Create source element for MP4
   const sourceMp4 = document.createElement('source');


### PR DESCRIPTION
Additional testing revealed there was an issue autoplaying content without page interaction.  
Previously, only safari worked. Now Chrome, edge, firefox works too. 
The issue was about setting the boolean attribute.  


Fix #31 



Test URLs:
- Before: https://main--24life--hlxsites.hlx.page/drafts/ashrigondeka/nutritionist-kelly-leveques-fab-four-to-get-in-shape


- After: 
- https://31-support-mp4-video-article-hero-block--24life--hlxsites.hlx.page/drafts/ashrigondeka/article-hero-video-1
- https://31-support-mp4-video-article-hero-block--24life--hlxsites.hlx.page/drafts/ashrigondeka/article-hero-video-2
- https://31-support-mp4-video-article-hero-block--24life--hlxsites.hlx.page/drafts/ashrigondeka/article-hero-video-3
- https://31-support-mp4-video-article-hero-block--24life--hlxsites.hlx.page/drafts/ashrigondeka/article-hero-video-4
- https://31-support-mp4-video-article-hero-block--24life--hlxsites.hlx.page/drafts/ashrigondeka/nutritionist-kelly-leveques-fab-four-to-get-in-shape

