### PR TITLE
#34 Setup web font din 2014 and a fallback

### DIFF
--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -6,7 +6,7 @@
 @font-face {
   font-family: "din-2014";
   src: url("https://use.typekit.net/af/570287/00000000000000007735afea/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff2"), url("https://use.typekit.net/af/570287/00000000000000007735afea/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff"), url("https://use.typekit.net/af/570287/00000000000000007735afea/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("opentype");
-  font-display: auto;
+  font-display: swap;
   font-style: italic;
   font-weight: 400;
   font-stretch: normal;
@@ -15,7 +15,7 @@
 @font-face {
   font-family: "din-2014";
   src: url("https://use.typekit.net/af/c2b6e5/00000000000000007735afee/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"), url("https://use.typekit.net/af/c2b6e5/00000000000000007735afee/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"), url("https://use.typekit.net/af/c2b6e5/00000000000000007735afee/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
-  font-display: auto;
+  font-display: swap;
   font-style: normal;
   font-weight: 400;
   font-stretch: normal;
@@ -24,7 +24,7 @@
 @font-face {
   font-family: "din-2014";
   src: url("https://use.typekit.net/af/2bc98d/00000000000000007735aff1/30/l?subset_id=2&fvd=n6&v=3") format("woff2"), url("https://use.typekit.net/af/2bc98d/00000000000000007735aff1/30/d?subset_id=2&fvd=n6&v=3") format("woff"), url("https://use.typekit.net/af/2bc98d/00000000000000007735aff1/30/a?subset_id=2&fvd=n6&v=3") format("opentype");
-  font-display: auto;
+  font-display: swap;
   font-style: normal;
   font-weight: 600;
   font-stretch: normal;
@@ -33,7 +33,7 @@
 @font-face {
   font-family: "din-2014";
   src: url("https://use.typekit.net/af/cce580/00000000000000007735aff2/30/l?subset_id=2&fvd=i6&v=3") format("woff2"), url("https://use.typekit.net/af/cce580/00000000000000007735aff2/30/d?subset_id=2&fvd=i6&v=3") format("woff"), url("https://use.typekit.net/af/cce580/00000000000000007735aff2/30/a?subset_id=2&fvd=i6&v=3") format("opentype");
-  font-display: auto;
+  font-display: swap;
   font-style: italic;
   font-weight: 600;
   font-stretch: normal;
@@ -42,7 +42,7 @@
 @font-face {
   font-family: "din-2014";
   src: url("https://use.typekit.net/af/efa8e9/00000000000000007735aff4/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i7&v=3") format("woff2"), url("https://use.typekit.net/af/efa8e9/00000000000000007735aff4/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i7&v=3") format("woff"), url("https://use.typekit.net/af/efa8e9/00000000000000007735aff4/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i7&v=3") format("opentype");
-  font-display: auto;
+  font-display: swap;
   font-style: italic;
   font-weight: 700;
   font-stretch: normal;
@@ -51,7 +51,7 @@
 @font-face {
   font-family: "din-2014";
   src: url("https://use.typekit.net/af/1fe1ce/00000000000000007735aff6/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff2"), url("https://use.typekit.net/af/1fe1ce/00000000000000007735aff6/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff"), url("https://use.typekit.net/af/1fe1ce/00000000000000007735aff6/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("opentype");
-  font-display: auto;
+  font-display: swap;
   font-style: normal;
   font-weight: 700;
   font-stretch: normal;
@@ -60,7 +60,7 @@
 @font-face {
   font-family: "din-2014";
   src: url("https://use.typekit.net/af/dc88f0/00000000000000007735aff7/30/l?subset_id=2&fvd=n8&v=3") format("woff2"), url("https://use.typekit.net/af/dc88f0/00000000000000007735aff7/30/d?subset_id=2&fvd=n8&v=3") format("woff"), url("https://use.typekit.net/af/dc88f0/00000000000000007735aff7/30/a?subset_id=2&fvd=n8&v=3") format("opentype");
-  font-display: auto;
+  font-display: swap;
   font-style: normal;
   font-weight: 800;
   font-stretch: normal;
@@ -69,7 +69,7 @@
 @font-face {
   font-family: "din-2014";
   src: url("https://use.typekit.net/af/245a1a/00000000000000007735aff8/30/l?subset_id=2&fvd=i8&v=3") format("woff2"), url("https://use.typekit.net/af/245a1a/00000000000000007735aff8/30/d?subset_id=2&fvd=i8&v=3") format("woff"), url("https://use.typekit.net/af/245a1a/00000000000000007735aff8/30/a?subset_id=2&fvd=i8&v=3") format("opentype");
-  font-display: auto;
+  font-display: swap;
   font-style: italic;
   font-weight: 800;
   font-stretch: normal;
@@ -78,7 +78,7 @@
 @font-face {
   font-family: "din-2014-narrow";
   src: url("https://use.typekit.net/af/2bdaca/00000000000000007735afe5/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"), url("https://use.typekit.net/af/2bdaca/00000000000000007735afe5/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"), url("https://use.typekit.net/af/2bdaca/00000000000000007735afe5/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
-  font-display: auto;
+  font-display: swap;
   font-style: normal;
   font-weight: 400;
   font-stretch: normal;
@@ -87,7 +87,7 @@
 @font-face {
   font-family: "din-2014-narrow";
   src: url("https://use.typekit.net/af/6be18e/00000000000000007735afeb/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff2"), url("https://use.typekit.net/af/6be18e/00000000000000007735afeb/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff"), url("https://use.typekit.net/af/6be18e/00000000000000007735afeb/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("opentype");
-  font-display: auto;
+  font-display: swap;
   font-style: normal;
   font-weight: 700;
   font-stretch: normal;
@@ -99,43 +99,43 @@
 @font-face {
   font-family:"Open Sans";
   src:url("https://use.typekit.net/af/8939f9/00000000000000007735a061/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff2"),url("https://use.typekit.net/af/8939f9/00000000000000007735a061/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff"),url("https://use.typekit.net/af/8939f9/00000000000000007735a061/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("opentype");
-  font-display:auto;font-style:normal;font-weight:700;font-stretch:normal;
+  font-display:swap;font-style:normal;font-weight:700;font-stretch:normal;
 }
 
 @font-face {
   font-family:"Open Sans";
   src:url("https://use.typekit.net/af/cb3467/00000000000000007735a069/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i7&v=3") format("woff2"),url("https://use.typekit.net/af/cb3467/00000000000000007735a069/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i7&v=3") format("woff"),url("https://use.typekit.net/af/cb3467/00000000000000007735a069/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i7&v=3") format("opentype");
-  font-display:auto;font-style:italic;font-weight:700;font-stretch:normal;
+  font-display:swap;font-style:italic;font-weight:700;font-stretch:normal;
 }
 
 @font-face {
   font-family:"Open Sans";
   src:url("https://use.typekit.net/af/d4e28f/00000000000000007735a072/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff2"),url("https://use.typekit.net/af/d4e28f/00000000000000007735a072/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("woff"),url("https://use.typekit.net/af/d4e28f/00000000000000007735a072/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i4&v=3") format("opentype");
-  font-display:auto;font-style:italic;font-weight:400;font-stretch:normal;
+  font-display:swap;font-style:italic;font-weight:400;font-stretch:normal;
 }
 
 @font-face {
   font-family:"Open Sans";
   src:url("https://use.typekit.net/af/f18587/00000000000000007735a07a/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),url("https://use.typekit.net/af/f18587/00000000000000007735a07a/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),url("https://use.typekit.net/af/f18587/00000000000000007735a07a/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
-  font-display:auto;font-style:normal;font-weight:400;font-stretch:normal;
+  font-display:swap;font-style:normal;font-weight:400;font-stretch:normal;
 }
 
 @font-face {
   font-family:"Open Sans condensed";
   src:url("https://use.typekit.net/af/2dfb40/00000000000000007735a05d/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff2"),url("https://use.typekit.net/af/2dfb40/00000000000000007735a05d/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff"),url("https://use.typekit.net/af/2dfb40/00000000000000007735a05d/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("opentype");
-  font-display:auto;font-style:normal;font-weight:700;font-stretch:normal;
+  font-display:swap;font-style:normal;font-weight:700;font-stretch:normal;
 }
 
 @font-face {
   font-family:"Open Sans condensed";
   src:url("https://use.typekit.net/af/066173/00000000000000007735a05f/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff2"),url("https://use.typekit.net/af/066173/00000000000000007735a05f/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("woff"),url("https://use.typekit.net/af/066173/00000000000000007735a05f/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n3&v=3") format("opentype");
-  font-display:auto;font-style:normal;font-weight:300;font-stretch:normal;
+  font-display:swap;font-style:normal;font-weight:300;font-stretch:normal;
 }
 
 @font-face {
   font-family:"Open Sans condensed";
   src:url("https://use.typekit.net/af/e117fb/00000000000000007735a062/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("woff2"),url("https://use.typekit.net/af/e117fb/00000000000000007735a062/30/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("woff"),url("https://use.typekit.net/af/e117fb/00000000000000007735a062/30/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=i3&v=3") format("opentype");
-  font-display:auto;font-style:italic;font-weight:300;font-stretch:normal;
+  font-display:swap;font-style:italic;font-weight:300;font-stretch:normal;
 }
 
 main .youtube-video {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -10,6 +10,30 @@
  * governing permissions and limitations under the License.
  */
 
+
+/* fallback font for din-2014 (normal - 400) */
+@font-face {
+  font-family: "din-2014-normal-400-fallback";
+  size-adjust: 93.8%;
+  src: local("Arial");
+}
+
+/* fallback font for Open Sans (normal - 400) */
+@font-face {
+  font-family: "open-sans-normal-400-fallback";
+  size-adjust: 104.78%;
+  src: local("Arial");
+}
+
+/* fallback font for Open Sans (italic - 400) */
+@font-face {
+  font-family: "open-sans-italic-400-fallback";
+  size-adjust: 98.879%;
+  src: local("Arial");
+}
+
+
+
 :root {
   /* colors */
   --link-color: #292929;


### PR DESCRIPTION
Fix #34 

https://developer.chrome.com/docs/lighthouse/performance/font-display/?utm_source=lighthouse&utm_medium=lr

- Ensure text remains visible during webfont load
<img width="976" alt="image" src="https://github.com/hlxsites/24life/assets/26192212/e4d32353-7b16-4cca-9e9b-40f445d91632">


Test URLs:
- Before: https://main--24life--hlxsites.hlx.page
- After: https://34-setup-web-font-din-2014-and-a-fallback--24life--hlxsites.hlx.page
