### PR TITLE
Improve Collections explorer

### DIFF
--- a/blocks/collections-explorer/collections-explorer.css
+++ b/blocks/collections-explorer/collections-explorer.css
@@ -46,6 +46,7 @@
     .collections-explorer .mobile-only {
         display: none;
     }
+
     .collections-explorer .explore span.msg {
         font-size: 21px;
     }

--- a/blocks/collections-explorer/collections-explorer.css
+++ b/blocks/collections-explorer/collections-explorer.css
@@ -13,18 +13,20 @@
     margin: auto;
 }
 
-.collections-explorer-container .explore .btn{
-    margin:0;
+.collections-explorer-container .explore .btn {
+    display: inline-block;
+    margin: 0;
     background-color: var(--footer-background-color);
     font-weight: lighter;
-    color:  var(--text-color-on-black-background);
+    color: var(--text-color-on-black-background);
     min-width: 100px;
     font-size: 14px;
     padding: 0 32px;
+    text-transform: uppercase;
 }
 
-.collections-explorer-container .explore span.msg{
-    margin-left:10px;
+.collections-explorer-container .explore span.msg {
+    margin-left: 10px;
     font-size: 14px;
     font-style: italic;
     font-weight: 300;
@@ -33,16 +35,16 @@
     color: var(--text-color);
 }
 
-.collections-explorer img{
+.collections-explorer img {
     width: 100%;
 }
 
-@media screen and (min-width: 600px){
+@media screen and (min-width: 600px) {
     .collections-explorer-container .explore span.msg {
         font-size: 21px;
     }
 
-    .collections-explorer-container .explore .btn{
+    .collections-explorer-container .explore .btn {
         height: 60px;
         line-height: 60px;
         min-width: 200px;
@@ -63,12 +65,12 @@
         background-size: cover;
     }
 
-    .collections-explorer .links-container{
+    .collections-explorer .links-container {
         width: 100%;
         background-color: rgb(0 0 0 / 50%);
     }
 
-    .collections-explorer .links-container ul{
+    .collections-explorer .links-container ul {
         list-style: none;
         text-align: center;
         padding: 2px 10px;
@@ -83,13 +85,13 @@
         color: var(--text-color-on-black-background);
     }
 
-    .collections-explorer .links-container ul a:hover{
+    .collections-explorer .links-container ul a:hover {
         background: rgb(51 51 51 / 50%);
     }
 }
 
-@media screen and (min-width: 900px){
-    .collections-explorer .links-container{
+@media screen and (min-width: 900px) {
+    .collections-explorer .links-container {
         width: 30%;
     }
 }

--- a/blocks/collections-explorer/collections-explorer.css
+++ b/blocks/collections-explorer/collections-explorer.css
@@ -119,5 +119,6 @@
 @media screen and (min-width: 900px) {
     .collections-explorer .desktop-only .links {
         margin-left: 70%;
+        width: 30%;
     }
 }

--- a/blocks/collections-explorer/collections-explorer.css
+++ b/blocks/collections-explorer/collections-explorer.css
@@ -67,7 +67,6 @@
         display: block;
         position: relative;
         width: 100%;
-        aspect-ratio: 1280/455;
     }
 
     .collections-explorer .desktop-only .pictures picture img {
@@ -88,12 +87,11 @@
 
 
     .collections-explorer  ul.links {
-        position: absolute;
+        position: relative;
         z-index: 3;
-        right: 0;
-        margin: 0;
         width: 100%;
         height: 100%;
+        margin: 0;
         background-color: rgb(0 0 0 / 50%);
         list-style: none;
         text-align: center;
@@ -120,6 +118,6 @@
 /* desktop */
 @media screen and (min-width: 900px) {
     .collections-explorer .desktop-only .links {
-        width: 30%;
+        margin-left: 70%;
     }
 }

--- a/blocks/collections-explorer/collections-explorer.css
+++ b/blocks/collections-explorer/collections-explorer.css
@@ -1,3 +1,4 @@
+/* mobile view */
 .collections-explorer h2.img-header {
     position: absolute;
     margin-top: 10px;
@@ -39,6 +40,7 @@
     width: 100%;
 }
 
+/* desktop */
 @media screen and (min-width: 600px) {
     .collections-explorer-container .explore span.msg {
         font-size: 21px;
@@ -57,23 +59,30 @@
         min-width: 100%;
     }
 
-    .collections-explorer .container {
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-end;
-        transition: background-image 0.5s ease-in-out;
-        background-size: cover;
+    .collections-explorer .desktop-only {
+        position: relative;
+        transition: display 0.5s ease-in-out;
     }
 
-    .collections-explorer .links-container {
+    .collections-explorer .desktop-only .pictures picture {
+        display: none;
+    }
+
+    .collections-explorer .desktop-only .pictures picture.active {
+        display: unset;
+    }
+
+
+    .collections-explorer  ul.links {
+        position: absolute;
+        right: 0;
+        margin: 0;
         width: 100%;
+        height: 100%;
         background-color: rgb(0 0 0 / 50%);
-    }
-
-    .collections-explorer .links-container ul {
         list-style: none;
         text-align: center;
-        padding: 2px 10px;
+        padding: 10px 0;
         font-size: var(--body-font-size-text);
         font-weight: 400;
         letter-spacing: 4px;
@@ -81,17 +90,19 @@
         text-transform: uppercase;
     }
 
-    .collections-explorer .links-container ul a {
+    .collections-explorer  ul.links a {
+        display: block;
+        margin: 0;
         color: var(--text-color-on-black-background);
     }
 
-    .collections-explorer .links-container ul a:hover {
+    .collections-explorer  ul.links a:hover {
         background: rgb(51 51 51 / 50%);
     }
 }
 
 @media screen and (min-width: 900px) {
-    .collections-explorer .links-container {
+    .collections-explorer .desktop-only .links {
         width: 30%;
     }
 }

--- a/blocks/collections-explorer/collections-explorer.css
+++ b/blocks/collections-explorer/collections-explorer.css
@@ -1,6 +1,6 @@
 /* shared mobile and desktop */
 
-.collections-explorer-container .explore .btn {
+.collections-explorer .explore .btn {
     display: inline-block;
     margin: 0;
     background-color: var(--footer-background-color);
@@ -12,7 +12,7 @@
     text-transform: uppercase;
 }
 
-.collections-explorer-container .explore span.msg {
+.collections-explorer .explore span.msg {
     margin-left: 10px;
     font-size: 14px;
     font-style: italic;
@@ -46,11 +46,11 @@
     .collections-explorer .mobile-only {
         display: none;
     }
-    .collections-explorer-container .explore span.msg {
+    .collections-explorer .explore span.msg {
         font-size: 21px;
     }
 
-    .collections-explorer-container .explore .btn {
+    .collections-explorer .explore .btn {
         height: 60px;
         line-height: 60px;
         min-width: 200px;

--- a/blocks/collections-explorer/collections-explorer.css
+++ b/blocks/collections-explorer/collections-explorer.css
@@ -1,18 +1,4 @@
-/* mobile view */
-.collections-explorer h2.img-header {
-    position: absolute;
-    margin-top: 10px;
-    margin-left: 10px;
-    color: var(--text-color-on-black-background);
-    font-size: 1rem;
-    font-weight: 350;
-    line-height: 1;
-}
-
-.collections-explorer-container .parent {
-    max-width: 100%;
-    margin: auto;
-}
+/* shared mobile and desktop */
 
 .collections-explorer-container .explore .btn {
     display: inline-block;
@@ -36,12 +22,30 @@
     color: var(--text-color);
 }
 
-.collections-explorer img {
+/* mobile view */
+.collections-explorer .mobile-only h2.img-header {
+    position: absolute;
+    margin-top: 10px;
+    margin-left: 10px;
+    color: var(--text-color-on-black-background);
+    font-size: 1rem;
+    font-weight: 350;
+    line-height: 1;
+}
+
+.collections-explorer .mobile-only img {
     width: 100%;
 }
 
-/* desktop */
+.collections-explorer .desktop-only {
+    display: none;
+}
+
+/* tablet and desktop */
 @media screen and (min-width: 600px) {
+    .collections-explorer .mobile-only {
+        display: none;
+    }
     .collections-explorer-container .explore span.msg {
         font-size: 21px;
     }
@@ -60,21 +64,32 @@
     }
 
     .collections-explorer .desktop-only {
+        display: block;
         position: relative;
-        transition: display 0.5s ease-in-out;
+        width: 100%;
+        aspect-ratio: 1280/455;
     }
 
-    .collections-explorer .desktop-only .pictures picture {
-        display: none;
+    .collections-explorer .desktop-only .pictures picture img {
+        position: absolute;
+        transition: opacity 0.5s ease-out;
+        opacity: 0;
+        z-index: 1;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
     }
 
-    .collections-explorer .desktop-only .pictures picture.active {
+    .collections-explorer .desktop-only .pictures picture.active img{
         display: unset;
+        opacity: 1;
+        z-index: 2;
     }
 
 
     .collections-explorer  ul.links {
         position: absolute;
+        z-index: 3;
         right: 0;
         margin: 0;
         width: 100%;
@@ -82,7 +97,8 @@
         background-color: rgb(0 0 0 / 50%);
         list-style: none;
         text-align: center;
-        padding: 10px 0;
+        padding: 20px 0;
+        box-sizing: border-box;
         font-size: var(--body-font-size-text);
         font-weight: 400;
         letter-spacing: 4px;
@@ -101,6 +117,7 @@
     }
 }
 
+/* desktop */
 @media screen and (min-width: 900px) {
     .collections-explorer .desktop-only .links {
         width: 30%;

--- a/blocks/collections-explorer/collections-explorer.js
+++ b/blocks/collections-explorer/collections-explorer.js
@@ -21,7 +21,6 @@ export default function decorate(block) {
   block.append(buildExploreCollectionsButton());
   block.append(buildDesktopView(linkImageList));
   block.append(buildMobileView(linkImageList));
-  // decorateLinkedPictures(block);
 }
 
 /**

--- a/blocks/collections-explorer/collections-explorer.js
+++ b/blocks/collections-explorer/collections-explorer.js
@@ -1,4 +1,3 @@
-import { decorateLinkedPictures } from '../../scripts/scripts.js';
 import { toClassName } from '../../scripts/lib-franklin.js';
 
 export default function decorate(block) {
@@ -19,11 +18,10 @@ export default function decorate(block) {
   }
 
   block.innerHTML = '';
+  block.append(buildExploreCollectionsButton());
   block.append(buildDesktopView(linkImageList));
   block.append(buildMobileView(linkImageList));
   // decorateLinkedPictures(block);
-
-  block.before(buildExploreCollectionsButton());
 }
 
 /**
@@ -62,6 +60,12 @@ function buildDesktopView(linkImageList) {
       picture.classList.add('active');
     }
     pictures.append(picture);
+
+    link.addEventListener('mouseover', (event) => {
+      event.preventDefault();
+      pictures.querySelector('picture.active').classList.remove('active');
+      picture.classList.add('active');
+    });
   }
 
   return desktopView;

--- a/blocks/collections-explorer/collections-explorer.js
+++ b/blocks/collections-explorer/collections-explorer.js
@@ -103,23 +103,11 @@ function buildMobileView(linkImageList) {
 }
 
 function buildExploreCollectionsButton() {
-  // Create a <div> element with class 'explore'
   const div = document.createElement('div');
   div.className = 'explore';
-
-  // Create button
-  const button = document.createElement('a');
-  button.className = 'btn';
-  button.href = '/collections';
-  button.textContent = 'Collections';
-
-  // Create a <span> element with class 'msg'
-  const span = document.createElement('span');
-  span.className = 'msg';
-  span.textContent = 'Explore what interests you…';
-
-  div.append(button);
-  div.append(span);
-
+  div.innerHTML = `
+    <a class="btn" href="/collections">Collections</a>
+    <span class="msg">Explore what interests you…</span>
+`;
   return div;
 }

--- a/blocks/collections-explorer/collections-explorer.js
+++ b/blocks/collections-explorer/collections-explorer.js
@@ -46,8 +46,7 @@ function buildDesktopView(linkImageList) {
   links.classList.add('links');
   desktopView.append(links);
 
-  for (let i = 0; i < linkImageList.length; i++) {
-    const pair = linkImageList[i];
+  linkImageList.forEach((pair, index) => {
     const link = pair.link.cloneNode(true);
     const picture = pair.picture.cloneNode(true);
 
@@ -56,7 +55,7 @@ function buildDesktopView(linkImageList) {
     links.append(li);
 
     picture.dataset.name = toClassName(link.textContent);
-    if (i === 0) {
+    if (index === 0) {
       picture.classList.add('active');
     }
     pictures.append(picture);
@@ -66,7 +65,7 @@ function buildDesktopView(linkImageList) {
       pictures.querySelector('picture.active').classList.remove('active');
       picture.classList.add('active');
     });
-  }
+  });
 
   return desktopView;
 }

--- a/blocks/collections-explorer/collections-explorer.js
+++ b/blocks/collections-explorer/collections-explorer.js
@@ -38,13 +38,13 @@ function buildDesktopView(linkImageList) {
   const desktopView = document.createElement('div');
   desktopView.classList.add('container', 'desktop-only');
 
-  const links = document.createElement('ul');
-  links.classList.add('links');
-  desktopView.append(links);
-
   const pictures = document.createElement('div');
   pictures.classList.add('pictures');
   desktopView.append(pictures);
+
+  const links = document.createElement('ul');
+  links.classList.add('links');
+  desktopView.append(links);
 
   for (let i = 0; i < linkImageList.length; i++) {
     const pair = linkImageList[i];

--- a/blocks/collections-explorer/collections-explorer.js
+++ b/blocks/collections-explorer/collections-explorer.js
@@ -108,9 +108,9 @@ function buildExploreCollectionsButton() {
   div.className = 'explore';
 
   // Create button
-  const button = document.createElement('button');
+  const button = document.createElement('a');
   button.className = 'btn';
-  button.onclick = () => window.location.replace('/collections');
+  button.href = '/collections';
   button.textContent = 'Collections';
 
   // Create a <span> element with class 'msg'

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -129,11 +129,6 @@ body {
   color: var(--text-color);
   background-color: var(--background-color);
   display: none;
-  height: 60000px;
-}
-
-main {
-  min-height: 10000vh;
 }
 
 body.appear {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -129,6 +129,11 @@ body {
   color: var(--text-color);
   background-color: var(--background-color);
   display: none;
+  height: 60000px;
+}
+
+main {
+  min-height: 10000vh;
 }
 
 body.appear {


### PR DESCRIPTION
update on #112 

addressed issues: 
 - previously the `<picture>` was not used but a background image. This prevents the browser from automatically selecting the right format and size. Also fixes a LHS issue. 
 - Media queries should not be used in JS unless absolutely necessary. It's easier to create the HTML markup for both the desktop and mobile, and then show/hide either of them in JS. 
 - Simplified code: decorateLinkedPictures is not needed, and static html can be setup easier with innerHTML. 
 - `<a>` should be used instead of button wherever possible, so the user can open the link in a new tab if needed. 
 

Test URLs:
- Before: https://main--24life--hlxsites.hlx.page/
- After: https://collections-explorer--24life--hlxsites.hlx.live/
