### PR TITLE
Simplify author-list

### DIFF
--- a/blocks/article-list/article-list.js
+++ b/blocks/article-list/article-list.js
@@ -2,7 +2,7 @@ import {
   getMetadata,
   loadBlock, readBlockConfig, toClassName,
 } from '../../scripts/lib-franklin.js';
-import { ffetcharticles } from '../../scripts/ffetch.js';
+import { ffetchArticles } from '../../scripts/ffetch.js';
 import { createCardBlock } from '../card/card.js';
 
 export default async function decorate(block) {
@@ -40,7 +40,7 @@ function removeEmptyKeyOrValue(obj) {
 }
 
 async function fetchArticlesAndAddCards(filters, block) {
-  const articles = await ffetcharticles('/articles.json').all();
+  const articles = await ffetchArticles('/articles.json').all();
   const numInitialLoadedArticles = 30;
   const actualLength = articles.filter((article) => Object.keys(filters).every(
     (key) => article[key]?.toLowerCase().includes(filters[key].toLowerCase()),

--- a/blocks/author-list/author-list.css
+++ b/blocks/author-list/author-list.css
@@ -74,16 +74,10 @@ div.author-list-container {
 
 /* on smaller screens, show everything in a single column. */
 @media (max-width: 991px) {
-  .author-list {
+  .author-list .author-grid {
     display: flex;
     flex-direction: column;
   }
 }
 
-@media (min-width: 1200px) {
-  .section.experts-page-heading > div,
-  .section.experts-page-editorial-staff > div,
-  .section.author-list-container > div {
-    max-width: 1150px;
-  }
-}
+

--- a/blocks/author-list/author-list.css
+++ b/blocks/author-list/author-list.css
@@ -20,6 +20,10 @@ div.author-list-container {
   width: 100%;
 }
 
+.author-list .author-list-item {
+  overflow-wrap: break-word;
+}
+
 .author-list .author-list-item img:hover {
   transform: scale(1.075);
 }
@@ -59,7 +63,7 @@ div.author-list-container {
 .author-list .author-grid {
   display: grid;
   gap: 2em;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 33%);
 }
 
 .author-list .author-load-more-container {

--- a/blocks/author-list/author-list.css
+++ b/blocks/author-list/author-list.css
@@ -20,7 +20,7 @@ div.author-list-container {
   width: 100%;
 }
 
-.author-list-item img:hover {
+.author-list .author-list-item img:hover {
   transform: scale(1.075);
 }
 
@@ -56,7 +56,7 @@ div.author-list-container {
   gap: 1rem;
 }
 
-.author-list .load-experts {
+.author-list .author-grid {
   display: grid;
   gap: 2em;
   grid-template-columns: repeat(3, 1fr);

--- a/blocks/author-list/author-list.js
+++ b/blocks/author-list/author-list.js
@@ -5,9 +5,9 @@ import { createOptimizedPicture, decorateIcons } from '../../scripts/lib-frankli
  * Shows list of authors, separated by role.
  *
  * Example block content:
- * | Staff  | Editorial Staff  |                  | Experts-Page-editorial-staff |
- * | Expert | Experts          | Some description |  |
- * | Writer | Contributing     | Writers          |  |
+ * | Staff  | Editorial Staff  |                  |
+ * | Expert | Experts          | Some description |
+ * | Writer | Contributing     | Writers          |
  */
 export default async function decorate(block) {
   const allAuthors = await ffetch('/authors.json').chunks(5000).all();
@@ -22,8 +22,7 @@ export default async function decorate(block) {
   });
   block.textContent = '';
   for (const role of roles) {
-    // eslint-disable-next-line no-await-in-loop
-    block.append(await createMarkupForRole(role, block, allAuthors));
+    block.append(createMarkupForRole(role, block, allAuthors));
   }
 }
 
@@ -40,7 +39,7 @@ function loadNext30Entries(iterator, authorCards, loadMoreContainer) {
   }
 }
 
-async function createMarkupForRole(role, block, allAuthors) {
+function createMarkupForRole(role, block, allAuthors) {
   const { filter, heading, description } = role;
   const authors = allAuthors
     .filter((author) => author.role.toLowerCase() === filter.toLowerCase())
@@ -58,6 +57,8 @@ async function createMarkupForRole(role, block, allAuthors) {
   authorCards.classList.add('author-grid');
 
   result.append(authorCards);
+
+  // always add the button to load more authors. It will be removed once the iterator is done
   const loadMoreContainer = document.createElement('div');
   loadMoreContainer.classList.add('author-load-more-container');
   loadMoreContainer.innerHTML = '<button class="author-list-load-more-button">Load more</button>';
@@ -66,6 +67,7 @@ async function createMarkupForRole(role, block, allAuthors) {
   });
   result.append(loadMoreContainer);
 
+  // initial load the first 30 entries
   loadNext30Entries(iterator, authorCards, loadMoreContainer);
   return result;
 }

--- a/blocks/author-list/author-list.js
+++ b/blocks/author-list/author-list.js
@@ -30,12 +30,12 @@ function loadNext30Entries(iterator, authorCards, loadMoreContainer) {
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < 30; i++) {
     const next = iterator.next();
-    const author = next.value;
-    if (!author) break;
-    authorCards.append(createAuthorCardBlock(author));
     if (next.done) {
       loadMoreContainer.remove();
     }
+    const author = next.value;
+    if (!author) break;
+    authorCards.append(createAuthorCardBlock(author));
   }
 }
 

--- a/blocks/author-list/author-list.js
+++ b/blocks/author-list/author-list.js
@@ -45,7 +45,7 @@ function createMarkupForRole(role, block, allAuthors) {
     .filter((author) => author.role.toLowerCase() === filter.toLowerCase())
     .toSorted((a, b) => a.name.localeCompare(b.name));
 
-  const iterator = makeArrayIterator(authors);
+  const iterator = authors.values();
 
   const result = document.createElement('div');
   const headingElement = document.createElement('h2');
@@ -70,17 +70,6 @@ function createMarkupForRole(role, block, allAuthors) {
   // initial load the first 30 entries
   loadNext30Entries(iterator, authorCards, loadMoreContainer);
   return result;
-}
-
-function makeArrayIterator(array) {
-  let nextIndex = 0;
-  return {
-    next() {
-      const result = { value: array[nextIndex], done: nextIndex + 1 >= array.length };
-      nextIndex += 1;
-      return result;
-    },
-  };
 }
 
 function p(content) {

--- a/blocks/author-list/author-list.js
+++ b/blocks/author-list/author-list.js
@@ -26,9 +26,24 @@ export default async function decorate(block) {
   }
 }
 
-function loadNext30Entries(iterator, authorCards, loadMoreContainer) {
+const mediaQuery = window.matchMedia('(min-width: 992px)');
+
+/**
+ * Returns the number of authors to display in one chunk
+ * @return {number}
+ */
+function getDisplayChunkSize() {
+  if (mediaQuery.matches) {
+    // desktop
+    return 30;
+  }
+  // mobile
+  return 10;
+}
+
+function displayNextEntries(iterator, authorCards, loadMoreContainer) {
   // eslint-disable-next-line no-plusplus
-  for (let i = 0; i < 30; i++) {
+  for (let i = 0; i < getDisplayChunkSize(); i++) {
     const next = iterator.next();
     if (next.done) {
       loadMoreContainer.remove();
@@ -63,12 +78,12 @@ function createMarkupForRole(role, block, allAuthors) {
   loadMoreContainer.classList.add('author-load-more-container');
   loadMoreContainer.innerHTML = '<button class="author-list-load-more-button">Load more</button>';
   loadMoreContainer.addEventListener('click', () => {
-    loadNext30Entries(iterator, authorCards, loadMoreContainer);
+    displayNextEntries(iterator, authorCards, loadMoreContainer);
   });
   result.append(loadMoreContainer);
 
   // initial load the first 30 entries
-  loadNext30Entries(iterator, authorCards, loadMoreContainer);
+  displayNextEntries(iterator, authorCards, loadMoreContainer);
   return result;
 }
 

--- a/blocks/author-list/author-list.js
+++ b/blocks/author-list/author-list.js
@@ -70,7 +70,6 @@ function createMarkupForRole(role, block, allAuthors) {
 
   const authorCards = document.createElement('div');
   authorCards.classList.add('author-grid');
-
   result.append(authorCards);
 
   // always add the button to load more authors. It will be removed once the iterator is done
@@ -82,7 +81,7 @@ function createMarkupForRole(role, block, allAuthors) {
   });
   result.append(loadMoreContainer);
 
-  // initial load the first 30 entries
+  // initial load the first entries
   displayNextEntries(iterator, authorCards, loadMoreContainer);
   return result;
 }

--- a/blocks/author-list/author-list.js
+++ b/blocks/author-list/author-list.js
@@ -28,7 +28,6 @@ export default async function decorate(block) {
 }
 
 function loadNext30Entries(iterator, authorCards, loadMoreContainer) {
-  // create the first 30 authors
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < 30; i++) {
     const next = iterator.next();

--- a/blocks/author-list/author-list.js
+++ b/blocks/author-list/author-list.js
@@ -1,90 +1,85 @@
-import { ffetcharticles } from '../../scripts/ffetch.js';
-import {
-  createOptimizedPicture, decorateIcons,
-} from '../../scripts/lib-franklin.js';
+import ffetch from '../../scripts/ffetch.js';
+import { createOptimizedPicture, decorateIcons } from '../../scripts/lib-franklin.js';
 
 /**
- * loads and decorates the footer
- * @param {Element} block The footer block element
+ * Shows list of authors, separated by role.
+ *
+ * Example block content:
+ * | Staff  | Editorial Staff  |                  | Experts-Page-editorial-staff |
+ * | Expert | Experts          | Some description |  |
+ * | Writer | Contributing     | Writers          |  |
  */
 export default async function decorate(block) {
-  const tempArray = [];
-  const arrayFilters = [];
-  const arrayHeading = [];
-  const arrayDes = [];
-  const arrayStyle = [];
-  const allauthors = await ffetcharticles('/authors.json').all();
-  [...block.children].forEach((row) => {
-    arrayFilters.push([...row.children][0].textContent);
-    arrayHeading.push([...row.children][1].textContent);
-    arrayDes.push([...row.children][2].textContent);
-    arrayStyle.push([...row.children][3].textContent);
-    row.textContent = '';
+  const allAuthors = await ffetch('/authors.json').chunks(5000).all();
+  const roles = [...block.children].map((row) => {
+    const cells = [...row.children];
+    return ({
+      filter: cells[0].textContent,
+      heading: cells[1].textContent,
+      description: cells[2].textContent,
+      style: cells[3].textContent,
+    });
   });
-  // eslint-disable-next-line
-  for (let i = 0; i < arrayFilters.length; i++) { await fetchAuthors(arrayFilters[i], block, tempArray, allauthors, arrayHeading[i], arrayDes[i], arrayStyle[i]).catch((e) => console.log(e));};
+  block.textContent = '';
+  for (const role of roles) {
+    // eslint-disable-next-line no-await-in-loop
+    block.append(await createMarkupForRole(role, block, allAuthors));
+  }
 }
 
-async function fetchAuthors(filter, block, tempArray, allauthors, head, desc, sty) {
-  // get all authors from authors.json and filter them by role
-  const authors = allauthors.filter((author) => author.role === filter);
-  const total = tempArray.reduce((sum, x) => { let sum1 = sum; sum1 += x; return sum1; }, 0);
-  // sort author list by name
-  authors.sort((a, b) => a.name.localeCompare(b.name));
+function loadNext30Entries(iterator, authorCards, loadMoreContainer) {
   // create the first 30 authors
-  const numInitialLodedAuthors = 30;
-  const firstAuthors = authors.slice(0, numInitialLodedAuthors);
-  const mainDiv = document.createElement('div');
-  const loadExperts = document.createElement('div');
-  const headingParentDiv = document.createElement('div');
-  const headingChildDiv = document.createElement('div');
-  const descDiv = document.createElement('div');
-  headingParentDiv.append(headingChildDiv);
-  headingParentDiv.append(descDiv);
-  mainDiv.append(headingParentDiv);
-  mainDiv.append(loadExperts);
-  loadExperts.classList.add('load-experts');
-  headingChildDiv.innerHTML = `<h2>${head}</h2>`;
-  if (desc) descDiv.innerHTML = `<p>${desc}</p>`;
-  if (sty) headingParentDiv.classList.add(sty);
-  await firstAuthors.forEach((author) => {
-    const newBlock = createAuthorCardBlock(author);
-    loadExperts.append(newBlock);
-  });
-  block.append(mainDiv);
-  // create load more button if there are more authors than shown
-  const counter = (document.querySelectorAll('.author-list-container .author-list.block .author-list-item').length - total) / numInitialLodedAuthors;
-  if ((authors.length - (numInitialLodedAuthors * counter)) > numInitialLodedAuthors) {
-    createLoadMoreButton(numInitialLodedAuthors, authors, block, total, loadExperts);
-  } else { tempArray.push(authors.length); }
+  // eslint-disable-next-line no-plusplus
+  for (let i = 0; i < 30; i++) {
+    const next = iterator.next();
+    const author = next.value;
+    if (!author) break;
+    authorCards.append(createAuthorCardBlock(author));
+    if (next.done) {
+      loadMoreContainer.remove();
+    }
+  }
 }
 
-function createLoadMoreButton(numInitialLodedAuthors, authors, block, total, loadExperts) {
+async function createMarkupForRole(role, block, allAuthors) {
+  const { filter, heading, description } = role;
+  const authors = allAuthors
+    .filter((author) => author.role.toLowerCase() === filter.toLowerCase())
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  const iterator = makeArrayIterator(authors);
+
+  const result = document.createElement('div');
+  const headingElement = document.createElement('h2');
+  headingElement.textContent = heading;
+  result.append(headingElement);
+  result.append(p(description));
+
+  const authorCards = document.createElement('div');
+  authorCards.classList.add('author-grid');
+
+  result.append(authorCards);
   const loadMoreContainer = document.createElement('div');
   loadMoreContainer.classList.add('author-load-more-container');
-  const loadMoreButton = document.createElement('button');
-  loadMoreContainer.append(loadMoreButton);
-  loadMoreButton.classList.add('author-list-load-more-button');
-  loadMoreButton.textContent = 'Load more';
-  loadMoreButton.addEventListener('click', async () => {
-    const counter = (document.querySelectorAll('.author-list-container .author-list.block .author-list-item').length - total) / numInitialLodedAuthors;
-    // eslint-disable-next-line
-    const nextAuthors = authors.slice(numInitialLodedAuthors * counter, (numInitialLodedAuthors * counter) + numInitialLodedAuthors);
-    await nextAuthors.forEach((author) => {
-      const newBlock = createAuthorCardBlock(author);
-      loadExperts.append(newBlock);
-    });
-    // eslint-disable-next-line
-    if ((authors.length - (numInitialLodedAuthors * counter)) > numInitialLodedAuthors) { loadExperts.append(loadMoreContainer); }
+  loadMoreContainer.innerHTML = '<button class="author-list-load-more-button">Load more</button>';
+  loadMoreContainer.addEventListener('click', () => {
+    loadNext30Entries(iterator, authorCards, loadMoreContainer);
   });
-  loadExperts.append(loadMoreContainer);
+  result.append(loadMoreContainer);
+
+  loadNext30Entries(iterator, authorCards, loadMoreContainer);
+  return result;
 }
 
-function buildAuthorListItem(className, content) {
-  const container = document.createElement('div');
-  container.classList.add(className);
-  container.append(...content);
-  return container;
+function makeArrayIterator(array) {
+  let nextIndex = 0;
+  return {
+    next() {
+      const result = { value: array[nextIndex], done: nextIndex + 1 >= array.length };
+      nextIndex += 1;
+      return result;
+    },
+  };
 }
 
 function p(content) {
@@ -93,7 +88,7 @@ function p(content) {
   return result;
 }
 
-/* convenience function to create a block from a JSON object from authors.json */
+/* create a block from a JSON object from authors.json */
 function createAuthorCardBlock(author) {
   const pictureP = p();
   pictureP.classList.add('author-image');
@@ -112,12 +107,15 @@ function createAuthorCardBlock(author) {
   // parse the author.links string and iterate over links
   addAuthorLinks(author, authorLinkContainer);
 
-  return buildAuthorListItem('author-list-item', [
+  const container = document.createElement('div');
+  container.classList.add('author-list-item');
+  container.append(
     pictureP,
     heading,
     p(author.description),
     authorLinkContainer,
-  ]);
+  );
+  return container;
 }
 
 function addAuthorLinks(author, authorLinkContainer) {

--- a/scripts/ffetch.js
+++ b/scripts/ffetch.js
@@ -1,3 +1,6 @@
+// Copied from https://github.com/Buuhuu/ffetch, see also the docs there.
+// If you change this file, please also make a pull request to the original.
+
 /* eslint-disable no-restricted-syntax,  no-await-in-loop */
 
 async function* request(url, context) {
@@ -165,7 +168,7 @@ export default function ffetch(url) {
   return assignOperations(generator, context);
 }
 
-export function ffetcharticles(url) {
+export function ffetchArticles(url) {
   let chunkSize = 5000;
   const fetch = (...rest) => window.fetch.apply(null, rest);
   const parseHtml = (html) => new window.DOMParser().parseFromString(html, 'text/html');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -352,8 +352,3 @@ div.experts-page-heading {
   padding-bottom: 13px;
   padding-top: 50px;
 }
-
-div.experts-page-editorial-staff {
-  margin: 0;
-  padding: 0;
-}


### PR DESCRIPTION
The author-list became a bit complicated, so I did a refactoring. See below some notes for clean code development. 

Feedback for previous implementation: 

 - do not run querySelectorAll on `document`. use `block` instead.
- don't use `// eslint-disable-next-line`. Instead fix it, or use specific disable.
- don't use unnamed variables like `tempArray` and `counter`; or shortened variables like `sty`. 
- let's use camelCase correctly. I changed `ffetcharticles` to `ffetchArticles`. 
- use objects with keys instead of multiple arrays with offsets. e.g. `const roles = [{filter: aFilter, b: 'x' }]`

I changed: 
- I replaced the complicated counter logic with an iterator. 
- I removed unnecessary `div` elements. 
- I removed the section styles, as it only made it more complex and I did not see it having any meaningful effect. 

Fix #124 #122

Test URLs:
- Before: https://main--24life--hlxsites.hlx.page/experts
- After: https://simplify-author-list--24life--hlxsites.hlx.live/experts
