### PR TITLE
Magazine Summary (footer) variant

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -33,7 +33,7 @@ async function buildSectionMenuContent(header, section) {
 
   CREATED[section] = true;
   try {
-    const menu = await fetch(`/fragments/menu-${section}.plain.html`);
+    const menu = await fetch(`/navigation/menu-${section}.plain.html`);
     if (menu.ok) {
       const fragment = document.createElement('div');
       fragment.classList.add('nav-fragment', section);

--- a/blocks/magazine-summary/magazine-summary.js
+++ b/blocks/magazine-summary/magazine-summary.js
@@ -10,8 +10,7 @@ import {
  */
 export default async function decorate(block) {
   const config = readBlockConfig(block);
-  config.isSubNav = block.classList.contains('navigation');
-  config.isFooter = block.classList.contains('footer');
+  config.isSubNav = block.closest('header');
   config.labels = block.querySelectorAll('div > div:nth-child(2) > p:first-child');
   config.links = [...block.querySelectorAll('div > div:nth-child(2) > p:not(:first-child) > a')];
   block.innerText = '';
@@ -46,9 +45,9 @@ function createCoverColumn(config) {
   titleH6.classList.add('red');
   if (!config.isSubNav) {
     // page
-    const title = config.isFooter ? config.title.toUpperCase() : getMetadata('og:title').toUpperCase();
-    const location = config.isFooter ? config.link : new URL(document.location).pathname;
-    const coverPic = config.isFooter ? config.image : getMetadata('og:image');
+    const title = config.title ?? getMetadata('og:title');
+    const location = config.link ?? new URL(document.location).pathname;
+    const coverPic = config.image ?? getMetadata('og:image');
     titleH4.textContent = `In This Issue - ${title}`;
     titleH6.textContent = location.split('/').pop().replaceAll(/-/g, ' ').toUpperCase();
     textCol.append(titleH4);
@@ -79,7 +78,7 @@ function createListColumn(config, index) {
   const sectionTitle = document.createElement('div');
   sectionTitle.classList.add('section-title', `${section}`);
   sectionTitle.style.setProperty('color', `var(--color-${section}-text)`);
-  if (!config.isSubNav && !config.isFooter) {
+  if (!config.links.length) {
     sectionTitle.textContent = config[section];
     links = document.querySelectorAll(`.card-container .card-wrapper .card.${section} h2 > a`);
   } else {

--- a/blocks/magazine-summary/magazine-summary.js
+++ b/blocks/magazine-summary/magazine-summary.js
@@ -11,6 +11,7 @@ import {
 export default async function decorate(block) {
   const config = readBlockConfig(block);
   config.isSubNav = block.classList.contains('navigation');
+  config.isFooter = block.classList.contains('footer');
   config.labels = block.querySelectorAll('div > div:nth-child(2) > p:first-child');
   config.links = [...block.querySelectorAll('div > div:nth-child(2) > p:not(:first-child) > a')];
   block.innerText = '';
@@ -44,14 +45,18 @@ function createCoverColumn(config) {
   const titleH6 = document.createElement('h6');
   titleH6.classList.add('red');
   if (!config.isSubNav) {
-    const title = getMetadata('og:title').toUpperCase();
+    // page
+    const title = config.isFooter ? config.title.toUpperCase() : getMetadata('og:title').toUpperCase();
+    const location = config.isFooter ? config.link : new URL(document.location).pathname;
+    const coverPic = config.isFooter ? config.image : getMetadata('og:image');
     titleH4.textContent = `In This Issue - ${title}`;
-    titleH6.textContent = new URL(document.location).pathname.split('/').pop().replaceAll(/-/g, ' ').toUpperCase();
+    titleH6.textContent = location.split('/').pop().replaceAll(/-/g, ' ').toUpperCase();
     textCol.append(titleH4);
     textCol.append(titleH6);
-    const coverImage = createOptimizedPicture(getMetadata('og:image'), title, false, [{ width: '200' }]);
+    const coverImage = createOptimizedPicture(coverPic, title, false, [{ width: '200' }]);
     textCol.append(coverImage);
   } else {
+    // navigation header
     const coverImage = createOptimizedPicture(config.image, config.title, false, [{ width: '200' }]);
     titleH4.textContent = config.title;
     titleH6.textContent = config.link.split('/').pop().replaceAll(/-/g, ' ').toUpperCase();
@@ -74,7 +79,7 @@ function createListColumn(config, index) {
   const sectionTitle = document.createElement('div');
   sectionTitle.classList.add('section-title', `${section}`);
   sectionTitle.style.setProperty('color', `var(--color-${section}-text)`);
-  if (!config.isSubNav) {
+  if (!config.isSubNav && !config.isFooter) {
     sectionTitle.textContent = config[section];
     links = document.querySelectorAll(`.card-container .card-wrapper .card.${section} h2 > a`);
   } else {

--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -16,7 +16,7 @@ body.article main .default-content-wrapper .block a {
 body.article main .article-social-media-buttons {
     display: flex;
     justify-content: center;
-    margin: 1em;
+    padding: 1em;
     gap: 1em;
 }
 

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -1,6 +1,7 @@
 import {
-  buildBlock, decorateBlock, decorateButtons, decorateIcons, getMetadata, toClassName,
+  buildBlock, decorateBlock, decorateButtons, decorateIcons, getMetadata, toClassName, loadBlocks,
 } from '../../scripts/lib-franklin.js';
+import { decorateMain } from '../../scripts/scripts.js';
 
 export default async function decorate(doc) {
   if (getMetadata('section')) {
@@ -41,8 +42,7 @@ export default async function decorate(doc) {
     const grayLine = document.createElement('hr');
     grayLine.classList.add('article-end-line');
     newSectionWrapper.append(grayLine);
-
-    newSectionWrapper.append('TODO: add issue summary here');
+    firstSection.parentElement.append(await createMagazineFooter());
   } else {
     newSectionWrapper.append(createArticleCarousel());
   }
@@ -135,4 +135,20 @@ function createSocialMediaButtons() {
   // noinspection JSIgnoredPromiseFromCall
   decorateIcons(socialMediaButtons);
   return socialMediaButtons;
+}
+
+async function createMagazineFooter() {
+  try {
+    const issue = getMetadata('issue').toLowerCase();
+    const summary = await fetch(`/fragments/magazine-footers/${issue}.plain.html`);
+    if (summary.ok) {
+      const fragment = document.createElement('div');
+      fragment.innerHTML = await summary.text();
+      decorateMain(fragment);
+      await loadBlocks(fragment);
+      return fragment;
+    }
+  } catch (e) {
+    throw e;
+  }
 }

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -138,17 +138,13 @@ function createSocialMediaButtons() {
 }
 
 async function createMagazineFooter() {
-  try {
     const issue = getMetadata('issue').toLowerCase();
     const summary = await fetch(`/fragments/magazine-footers/${issue}.plain.html`);
+    const fragment = document.createElement('div');
     if (summary.ok) {
-      const fragment = document.createElement('div');
       fragment.innerHTML = await summary.text();
       decorateMain(fragment);
       await loadBlocks(fragment);
-      return fragment;
     }
-  } catch (e) {
-    throw e;
-  }
+  return fragment;
 }

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -138,13 +138,13 @@ function createSocialMediaButtons() {
 }
 
 async function createMagazineFooter() {
-    const issue = getMetadata('issue').toLowerCase();
-    const summary = await fetch(`/fragments/magazine-footers/${issue}.plain.html`);
-    const fragment = document.createElement('div');
-    if (summary.ok) {
-      fragment.innerHTML = await summary.text();
-      decorateMain(fragment);
-      await loadBlocks(fragment);
-    }
+  const issue = getMetadata('issue').toLowerCase();
+  const summary = await fetch(`/fragments/magazine-footers/${issue}.plain.html`);
+  const fragment = document.createElement('div');
+  if (summary.ok) {
+    fragment.innerHTML = await summary.text();
+    decorateMain(fragment);
+    await loadBlocks(fragment);
+  }
   return fragment;
 }

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -28,22 +28,27 @@ export default async function decorate(doc) {
   newSection.append(newSectionWrapper);
   firstSection.parentElement.append(newSection);
 
-  // add a thin gray line to break this up from the previous section
-  const line = document.createElement('hr');
-  line.classList.add('article-end-line');
-  newSectionWrapper.append(line);
+  if (!getMetadata('issue')) {
+    // add a thin gray line to break this up from the previous section
+    const line = document.createElement('hr');
+    line.classList.add('article-end-line');
+    newSectionWrapper.append(line);
+    newSectionWrapper.append(createSocialMediaButtons());
+  }
 
-  newSectionWrapper.append(createSocialMediaButtons());
   getMetadata('authors').split(',').forEach((author) => {
     newSectionWrapper.append(createAuthorBlock(author));
   });
+
   if (getMetadata('issue')) {
+    const magSummary = createNewSection();
+    firstSection.parentElement.append(magSummary);
+    magSummary.replaceWith((await createMagazineFooter()));
+  } else {
     // add a thin gray line to break this up from the previous section
     const grayLine = document.createElement('hr');
     grayLine.classList.add('article-end-line');
     newSectionWrapper.append(grayLine);
-    firstSection.parentElement.append(await createMagazineFooter());
-  } else {
     newSectionWrapper.append(createArticleCarousel());
   }
 
@@ -139,7 +144,7 @@ function createSocialMediaButtons() {
 
 async function createMagazineFooter() {
   const issue = getMetadata('issue').toLowerCase();
-  const summary = await fetch(`/fragments/magazine-footers/${issue}.plain.html`);
+  const summary = await fetch(`/navigation/magazine-summary/${issue}.plain.html`);
   const fragment = document.createElement('div');
   if (summary.ok) {
     fragment.innerHTML = await summary.text();


### PR DESCRIPTION
This variant will be added to the bottom of articles that are part of a magazine issue.

Since this will have to be persisted, it will use a fragment in the `24life > fragments > magazine-footers` folder.
Going forward, the current `menu-magazine` fragment will be copied into the `magazine-footers` folder and renamed to the <volume-issue>. Then the `menu-magazine` can be updated with the new issue.

**This means we need to import the previous issue summaries.** See issue: #165

Fix #164 

Test URLs:
- Before: https://main--24life--hlxsites.hlx.live/focus/2020/maye-musk-is-unstoppable
- After: https://mag-summary-footer--24life--hlxsites.hlx.live/focus/2020/maye-musk-is-unstoppable
